### PR TITLE
ci(release): fail closed on auth-bearing npm config before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,13 @@ jobs:
           echo "release SHA: $GITHUB_SHA"
           git log v2.1.2..HEAD --format='%H%n%s%n%b%n---'
           echo "::endgroup::"
-          echo "::group::Sanitized npm auth-config (repository/user/global) — must show no nonempty auth-bearing key"
-          echo "repository .npmrc:"; [ -f .npmrc ] && sed -E 's/(_authToken=).*/\1<redacted>/; s/(_auth=).*/\1<redacted>/; s/(password=).*/\1<redacted>/; s/(:_authToken=).*/\1<redacted>/' .npmrc || echo "(none)"
-          echo "user .npmrc:"; [ -f ~/.npmrc ] && sed -E 's/(_authToken=).*/\1<redacted>/; s/(_auth=).*/\1<redacted>/; s/(password=).*/\1<redacted>/; s/(:_authToken=).*/\1<redacted>/' ~/.npmrc || echo "(none)"
-          echo "globalconfig path:"; npm config get globalconfig
+          echo "::group::npm auth-config evidence (repository/user/global + npm_config_* env, fail-closed)"
+          # Resolves repo .npmrc + npm config get userconfig/globalconfig, inspects
+          # each for nonempty auth-bearing keys (incl. scoped/case/spacing variants
+          # of _authToken/_auth/_password/password/token/username/otp/certfile/keyfile)
+          # and scans npm_config_* env. Exits nonzero (failing this step before
+          # semantic-release) on any nonempty auth-bearing value; never prints values.
+          bash scripts/release/check-npm-auth.sh
           echo "::endgroup::"
           echo "::group::Token env absence (NPM_TOKEN/NODE_AUTH_TOKEN must be absent)"
           echo "NPM_TOKEN=${NPM_TOKEN:+<present>}"

--- a/scripts/release/check-npm-auth-probes.sh
+++ b/scripts/release/check-npm-auth-probes.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Local probes for scripts/release/check-npm-auth.sh (VAL-REL-007 evidence).
+#
+# Positive: a clean npm config passes.
+# Negative (disposable temp fixtures): every auth-bearing key/value is rejected
+#   and the fixture value is never printed. Covers _authToken, _auth,
+#   _password/password, token, username, otp, certfile, keyfile, scoped
+#   registry keys, and case/spacing variants. A disposable npm_config_*
+#   environment probe is included.
+#
+# Run: bash scripts/release/check-npm-auth-probes.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$SCRIPT_DIR/check-npm-auth.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Non-sensitive fixture value used only to assert it never appears in output.
+MARKER='probe-leak-fixture-9f3c2a'
+pass=0
+fail=0
+
+# run_check <file> [extra env NAME=VAL ...]
+# Captures combined output into RUN_OUT and the exit code into RUN_RC.
+# env -i isolates the probes from the host shell so the positive probe is
+# deterministic and the env probe tests only the intended variable.
+run_check() {
+  file="$1"; shift
+  RUN_OUT="$(mktemp)"
+  set +e
+  env -i PATH="$PATH" "$@" bash "$CHECK" "$file" >"$RUN_OUT" 2>&1
+  RUN_RC=$?
+  set -e
+}
+
+assert_passes() {
+  label="$1"; file="$2"; shift 2
+  run_check "$file" "$@"
+  if [ "$RUN_RC" -eq 0 ] && ! grep -qF "$MARKER" "$RUN_OUT"; then
+    echo "PASS (positive): $label"; pass=$((pass + 1))
+  else
+    leaked=no; grep -qF "$MARKER" "$RUN_OUT" && leaked=yes
+    echo "FAIL (positive): $label (rc=$RUN_RC, leaked=$leaked)"; fail=$((fail + 1))
+    cat "$RUN_OUT"
+  fi
+}
+
+assert_rejected() {
+  label="$1"; file="$2"; shift 2
+  run_check "$file" "$@"
+  if [ "$RUN_RC" -ne 0 ] && ! grep -qF "$MARKER" "$RUN_OUT"; then
+    echo "PASS (negative): $label"; pass=$((pass + 1))
+  else
+    leaked=no; grep -qF "$MARKER" "$RUN_OUT" && leaked=yes
+    echo "FAIL (negative): $label (rc=$RUN_RC, leaked=$leaked)"; fail=$((fail + 1))
+    cat "$RUN_OUT"
+  fi
+}
+
+# Positive: clean config has no auth-bearing key.
+cat >"$WORK/clean.npmrc" <<'EOF'
+registry=https://registry.npmjs.org/
+fund=false
+audit=false
+EOF
+assert_passes 'clean config passes' "$WORK/clean.npmrc"
+
+# Negative file fixtures: one auth-bearing key each. The shared value is the
+# fixture marker; the check must reject each and never echo it.
+write_fixture() { printf '%s\n' "$1" >"$WORK/fixture.npmrc"; }
+
+write_fixture "_authToken=$MARKER";                      assert_rejected '_authToken' "$WORK/fixture.npmrc"
+write_fixture "_auth=$MARKER";                          assert_rejected '_auth' "$WORK/fixture.npmrc"
+write_fixture "_password=$MARKER";                      assert_rejected '_password' "$WORK/fixture.npmrc"
+write_fixture "password=$MARKER";                       assert_rejected 'password' "$WORK/fixture.npmrc"
+write_fixture "token=$MARKER";                          assert_rejected 'token' "$WORK/fixture.npmrc"
+write_fixture "username=$MARKER";                       assert_rejected 'username' "$WORK/fixture.npmrc"
+write_fixture "otp=$MARKER";                            assert_rejected 'otp' "$WORK/fixture.npmrc"
+write_fixture "certfile=$MARKER";                        assert_rejected 'certfile' "$WORK/fixture.npmrc"
+write_fixture "keyfile=$MARKER";                         assert_rejected 'keyfile' "$WORK/fixture.npmrc"
+write_fixture "@myscope:_authToken=$MARKER";            assert_rejected 'scoped @myscope:_authToken' "$WORK/fixture.npmrc"
+write_fixture "//registry.example.com/:_authToken=$MARKER"; assert_rejected 'scoped URL _authToken' "$WORK/fixture.npmrc"
+write_fixture "_AuthToken=$MARKER";                     assert_rejected 'case variant _AuthToken' "$WORK/fixture.npmrc"
+printf '  _authToken  =  %s  \n' "$MARKER" >"$WORK/fixture.npmrc"; assert_rejected 'spacing variant' "$WORK/fixture.npmrc"
+
+# Negative env probe: a disposable npm_config_* auth var must be rejected too.
+assert_rejected 'env npm_config__authtoken' "$WORK/clean.npmrc" "npm_config__authtoken=$MARKER"
+
+echo "---"
+echo "probes: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/release/check-npm-auth.sh
+++ b/scripts/release/check-npm-auth.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Pre-publication npm auth-config evidence (VAL-REL-007).
+#
+# Resolves and inspects repository, user, and global npm configuration plus
+# npm_config_* environment keys. Fails closed (nonzero exit) on any nonempty
+# auth-bearing value. Never prints secret values — only scope, file path,
+# line number, and key name.
+#
+# Covers scoped registry keys and case/spacing variants of _authToken, _auth,
+# _password/password, token, username, otp, certfile, and keyfile.
+#
+# Usage:
+#   check-npm-auth.sh            # resolve repo .npmrc + user + global config
+#   check-npm-auth.sh <file>...  # inspect the given file(s) instead (probes)
+#
+# ponytail: one guard in the shared place; the release workflow and the local
+# probes both invoke this script so the logic is tested once.
+set -euo pipefail
+
+# Inspect a single npm config file. Args: scope, file.
+# Skip absent/comment/blank lines. Parse key=value, trim whitespace, lowercase
+# the key, strip any scope prefix (everything up to and including ':') so
+# scoped keys like @scope:_authToken or //host/path/:_authToken collapse to
+# _authtoken. Reject nonempty auth-bearing keys; emit only the key name.
+check_file() {
+  scope="$1"
+  file="$2"
+  if [ -z "$file" ] || [ "$file" = "undefined" ] || [ "$file" = "null" ] || [ ! -e "$file" ]; then
+    echo "$scope npm config absent (OK)"
+    return 0
+  fi
+  echo "$scope npm config path: $file"
+  awk -v scope="$scope" '
+    /^[[:space:]]*($|#|;)/ { next }
+    {
+      eq = index($0, "=")
+      if (!eq) next
+      key = substr($0, 1, eq - 1)
+      val = substr($0, eq + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+      low = tolower(key)
+      sub(/^.*:/, "", low)
+      if (low ~ /^(_authtoken|_auth|_password|password|token|username|otp|certfile|keyfile)$/ && val != "") {
+        printf "ERROR: nonempty npm auth-bearing key in %s config at line %d: %s\n", scope, NR, low > "/dev/stderr"
+        bad = 1
+      }
+    }
+    END { exit (bad ? 1 : 0) }
+  ' "$file"
+}
+
+# Scan exported npm_config_* environment keys for auth-bearing names with
+# nonempty values. Emit only the variable name, never its value.
+check_env() {
+  bad=0
+  while IFS= read -r name; do
+    val="${!name:-}"
+    [ -n "$val" ] || continue
+    lower=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+    case "$lower" in
+      npm_config_*authtoken*|npm_config_*_auth*|npm_config_*password*|npm_config_*token*|npm_config_*username*|npm_config_*otp*|npm_config_*certfile*|npm_config_*keyfile*)
+        echo "ERROR: nonempty npm auth-bearing environment config: $name" >&2
+        bad=1
+        ;;
+    esac
+  done < <(compgen -e)
+  return $bad
+}
+
+status=0
+if [ "$#" -gt 0 ]; then
+  i=0
+  for f in "$@"; do
+    i=$((i + 1))
+    check_file "file$i" "$f" || status=1
+  done
+else
+  check_file repository "$PWD/.npmrc" || status=1
+  check_file user "$(npm config get userconfig)" || status=1
+  check_file global "$(npm config get globalconfig)" || status=1
+fi
+check_env || status=1
+
+if [ "$status" -eq 0 ]; then
+  echo "no nonempty npm auth-bearing config found (OK)"
+fi
+exit $status


### PR DESCRIPTION
## Description

VAL-REL-007 scrutiny fix for the ci-release blocker. The pre-publication evidence step in `.github/workflows/release.yml` previously only redacted and printed npm auth config (via `sed`) without failing, did not inspect global config contents, did not scan `npm_config_*` environment keys, and missed several auth-bearing key variants.

Replaced the sed-based dump with `scripts/release/check-npm-auth.sh`, which:
- Resolves repository `.npmrc`, user (`npm config get userconfig`), and global (`npm config get globalconfig`) npm config paths and inspects each file's contents.
- Scans `npm_config_*` environment keys.
- Fails closed (nonzero exit, failing the step before semantic-release) on any nonempty auth-bearing value.
- Never prints values — only scope, file path, line number, and key name.
- Covers scoped registry keys and case/spacing variants of `_authToken`, `_auth`, `_password`/`password`, `token`, `username`, `otp`, `certfile`, and `keyfile`.

Added `scripts/release/check-npm-auth-probes.sh`: local positive probe (clean config passes) and disposable negative probes (every auth-bearing fixture is rejected and the fixture value is never printed, plus an `npm_config_*` env probe).

## Related Issue

Scrutiny blocker for VAL-REL-007 (OIDC authorizes npm publication — effective repo/user/global npm config must contain no nonempty auth-bearing key, inspected with values redacted).

## Potential Risk & Impact

Low. Only touches the release workflow and adds a release-only shell script (not packaged into the npm tarball — the `files` field still ships only `build` + `readme.md`). No source, public API, package surface, runtime dependency, or build output change.

This commit is `ci:` type (non-release-bearing), so merging it runs the master release workflow as a semantic-release no-op: no new npm version, git tag, or GitHub Release beyond 2.2.0.

## How Has This Been Tested?

- `bash scripts/release/check-npm-auth-probes.sh` — 15/15 probes pass (positive clean config; negative for each auth-bearing key, scoped, case, spacing, and env variant; no-leak asserted).
- Node 22 and Node 24 local gates pass: `npm ci`, typecheck, lint, 150 Jest tests, build; Node 24 additionally `npm audit --audit-level=moderate` and `npm run smoke`.
- `release.yml` validated as YAML and prettier-compliant.
