### PR TITLE
ci(release): fail closed on npm config resolver failures

### DIFF
--- a/scripts/release/check-npm-auth-probes.sh
+++ b/scripts/release/check-npm-auth-probes.sh
@@ -14,6 +14,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK="$SCRIPT_DIR/check-npm-auth.sh"
 WORK="$(mktemp -d)"
+# Clean cwd with no .npmrc so default-mode resolver probes inspect only the
+# stubbed npm resolver, never a host repository config.
+mkdir -p "$WORK/clean-cwd"
 trap 'rm -rf "$WORK"' EXIT
 
 # Non-sensitive fixture value used only to assert it never appears in output.
@@ -58,6 +61,43 @@ assert_rejected() {
   fi
 }
 
+# run_check_default <stub-dir> [extra env NAME=VAL ...]
+# Runs the check in default mode (no file args; resolves userconfig/globalconfig
+# via the stubbed npm on PATH) from the clean temp cwd. Captures combined
+# output into RUN_OUT and the exit code into RUN_RC.
+run_check_default() {
+  stubdir="$1"; shift
+  RUN_OUT="$(mktemp)"
+  set +e
+  ( cd "$WORK/clean-cwd" && env -i PATH="$stubdir:$PATH" "$@" bash "$CHECK" >"$RUN_OUT" 2>&1 )
+  RUN_RC=$?
+  set -e
+}
+
+# assert_resolver_fails <label> <stub-body>
+# A stubbed npm that makes `npm config get userconfig`/`globalconfig` fail must
+# fail the auth guard closed: nonzero exit, no misleading user/global
+# "absent (OK)" success, no final success line, and no value leak.
+assert_resolver_fails() {
+  label="$1"; stub_body="$2"
+  stubdir="$(mktemp -d)"
+  printf '%s\n' "$stub_body" >"$stubdir/npm"
+  chmod +x "$stubdir/npm"
+  run_check_default "$stubdir"
+  rm -rf "$stubdir"
+  if [ "$RUN_RC" -ne 0 ] \
+     && ! grep -qF 'user npm config absent (OK)' "$RUN_OUT" \
+     && ! grep -qF 'global npm config absent (OK)' "$RUN_OUT" \
+     && ! grep -qF 'no nonempty npm auth-bearing config found (OK)' "$RUN_OUT" \
+     && ! grep -qF "$MARKER" "$RUN_OUT"; then
+    echo "PASS (resolver-fail): $label"; pass=$((pass + 1))
+  else
+    leaked=no; grep -qF "$MARKER" "$RUN_OUT" && leaked=yes
+    echo "FAIL (resolver-fail): $label (rc=$RUN_RC, leaked=$leaked)"; fail=$((fail + 1))
+    cat "$RUN_OUT"
+  fi
+}
+
 # Positive: clean config has no auth-bearing key.
 cat >"$WORK/clean.npmrc" <<'EOF'
 registry=https://registry.npmjs.org/
@@ -86,6 +126,17 @@ printf '  _authToken  =  %s  \n' "$MARKER" >"$WORK/fixture.npmrc"; assert_reject
 
 # Negative env probe: a disposable npm_config_* auth var must be rejected too.
 assert_rejected 'env npm_config__authtoken' "$WORK/clean.npmrc" "npm_config__authtoken=$MARKER"
+
+# Negative resolver probes (Bash 3.2 compatible): a stubbed npm that makes
+# `npm config get userconfig`/`globalconfig` fail must fail the auth guard
+# closed — nonzero exit, no misleading "absent (OK)" success, no value leak.
+# Covers both nonzero-exit and empty-output resolver failures; a resolver
+# failure must never mask as an absent-config success.
+assert_resolver_fails 'npm config get exits nonzero' '#!/bin/sh
+exit 1'
+
+assert_resolver_fails 'npm config get returns empty' '#!/bin/sh
+exit 0'
 
 echo "---"
 echo "probes: $pass passed, $fail failed"

--- a/scripts/release/check-npm-auth.sh
+++ b/scripts/release/check-npm-auth.sh
@@ -68,6 +68,27 @@ check_env() {
   return $bad
 }
 
+# Resolve an npm config path via `npm config get <key>`. Args: scope, key.
+# Sets RESOLVED on success and returns 0. Fails closed (returns 1, stderr
+# message) when the resolver exits nonzero OR returns empty/undefined/null —
+# a resolver failure must never mask as an "absent (OK)" success. Emits only
+# scope/key/failure-mode, never a value.
+resolve_npm_config_path() {
+  scope="$1"; key="$2"
+  out=$(npm config get "$key" 2>/dev/null) || {
+    echo "ERROR: $scope npm config resolver 'npm config get $key' failed (nonzero exit)" >&2
+    return 1
+  }
+  case "$out" in
+    ""|undefined|null)
+      echo "ERROR: $scope npm config resolver 'npm config get $key' returned empty/undefined/null" >&2
+      return 1
+      ;;
+  esac
+  RESOLVED="$out"
+  return 0
+}
+
 status=0
 if [ "$#" -gt 0 ]; then
   i=0
@@ -77,8 +98,11 @@ if [ "$#" -gt 0 ]; then
   done
 else
   check_file repository "$PWD/.npmrc" || status=1
-  check_file user "$(npm config get userconfig)" || status=1
-  check_file global "$(npm config get globalconfig)" || status=1
+  # Resolve user/global paths separately so a resolver failure fails closed
+  # instead of masking as "absent (OK)". check_file runs only on a successful
+  # resolve; a failed resolve sets status=1 and emits no success message.
+  resolve_npm_config_path user userconfig && check_file user "$RESOLVED" || status=1
+  resolve_npm_config_path global globalconfig && check_file global "$RESOLVED" || status=1
 fi
 check_env || status=1
 


### PR DESCRIPTION
## Description

Fixes the remaining `ci-release` scrutiny blocker in `scripts/release/check-npm-auth.sh`.

`check-npm-auth.sh` previously resolved `npm config get userconfig` and `globalconfig` inside command substitutions passed directly to `check_file`:

```sh
check_file user "$(npm config get userconfig)" || status=1
check_file global "$(npm config get globalconfig)" || status=1
```

If `npm config get` exited nonzero or returned empty/`undefined`/`null`, the command substitution yielded an empty path, `check_file` reported `"absent (OK)"` and returned 0, so `|| status=1` never fired. A resolver failure was masked as a misleading absent-config success instead of failing closed.

This PR resolves each path via a separate assignment that captures both output and exit code (`resolve_npm_config_path`), fails closed when either resolver exits nonzero or returns empty/`undefined`/`null`, and runs `check_file` only on a successful resolve. Resolver failures emit only scope/key/failure-mode, never a value.

Also adds isolated Bash-3.2-compatible negative probes with a stubbed `npm` executable covering both nonzero-exit and empty-output resolver failures, asserting nonzero exit, no misleading `absent (OK)` success, and no value leak. Existing no-leak checks are preserved.

## Type of change

- [x] 🐛 Bug fix (non-release-bearing `ci:` commit)

## Potential Risk & Impact

- Bash-only change to the pre-publication auth guard and its probes; no TypeScript, build, package, or runtime surface touched.
- The commit is `ci(release):`, which is non-release-bearing for semantic-release, so the post-merge master release workflow is expected to run as a no-op (no new npm version, tag, or GitHub Release).

## How Has This Been Tested?

- `bash scripts/release/check-npm-auth-probes.sh` — 17/17 probes pass on macOS bash 3.2, including the two new resolver-failure negative cases.
- Manual positive resolver check with a stubbed `npm` returning a clean config path: exits 0 with `no nonempty npm auth-bearing config found (OK)`.
- Node 22 gate: typecheck, lint, 150 tests, build — all green.
- Node 24 gate: typecheck, lint, 150 tests, build, audit (0 vulnerabilities), smoke (CJS/ESM/UMD/ES5/strict-TS) — all green.
