### PR TITLE
fix(Tree): make everyBreathFirst traverse breadth-first

### DIFF
--- a/src/Tree.ts
+++ b/src/Tree.ts
@@ -115,7 +115,7 @@ class Tree {
    */
   everyBreathFirst(fn: Function): boolean {
     return Boolean(
-      this._traverseDepthFirst(fn, {
+      this._traverseBreathFirst(fn, {
         every: true,
         returnBoolean: true
       })

--- a/tests/Tree.test.ts
+++ b/tests/Tree.test.ts
@@ -266,6 +266,19 @@ describe('Tree', () => {
         expect(tree.everyBreathFirst(fn)).toBe(true);
         expect(fn.mock.calls.length).toBe(3);
       });
+      test('visits nodes in breadth-first order', () => {
+        const tree = new Tree();
+        tree.root = new Node(1);
+        tree.root.addChild(2);
+        tree.root.addChild(3);
+        tree.root.children[0].addChild(4);
+        const visited: Array<NodeOrNull> = [];
+        tree.everyBreathFirst((node: Node) => {
+          visited.push(node);
+          return true;
+        });
+        expect(nodesData(visited)).toEqual([1, 2, 3, 4]);
+      });
     });
     describe('returns false', () => {
       test('1 node null', () => {


### PR DESCRIPTION
Fixes #23.

`everyBreathFirst` called `_traverseDepthFirst` (copy-paste from `everyDepthFirst`), so breadth-first "every" actually walked depth-first. Routes it through `_traverseBreathFirst`.

Adds an order-dependent test that records visit order and asserts breadth-first traversal `[1,2,3,4]`; it fails under the old depth-first call (`[1,2,4,3]`).