### PR TITLE
fix(create): use === in createTreeFromFlatArray root guard

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -248,7 +248,7 @@ export const createTreeFromFlatArray = (
     createTreeArrayFromFlatArray(mappedFlatArray);
   if (!treeArray.length) {
     return new Tree();
-  } else if ((treeArray.length = 1)) {
+  } else if (treeArray.length === 1) {
     return createTreeFromTreeArray(treeArray);
   } else {
     // TODO: add functionality

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -334,6 +334,17 @@ describe('createTreeFromFlatArray', () => {
       });
     });
   });
+  describe('throws on arrays with more than one root', () => {
+    test('throws when the flat array has multiple roots', () => {
+      const list: Array<ObjectAnyProperties> = [
+        { id: 'a', name: 'A', parentId: null },
+        { id: 'b', name: 'B', parentId: null }
+      ];
+      expect(() => createTreeFromFlatArray(list)).toThrow(
+        /only accepts an array with 0 or 1 node/
+      );
+    });
+  });
   describe('custom object properties', () => {
     test('from array with 1 root', () => {
       const list: Array<ObjectAnyProperties> = [


### PR DESCRIPTION
Fixes #22.

`(treeArray.length = 1)` was an assignment (always truthy), so the multi-root guard was dead code and multi-root arrays were silently truncated to one element. Uses `===` so the `>1`-node guard throws as intended.

Adds a test asserting that a flat array with two roots throws `/only accepts an array with 0 or 1 node/`; it fails under the old assignment (no throw).